### PR TITLE
Add Dockerfile and instructions for running bitchat-terminal with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Build stage
+FROM rust:1.88-slim-trixie AS builder
+
+RUN apt-get update && \
+    apt-get install -y pkg-config libdbus-1-dev libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+RUN cargo build --release
+
+# Runtime stage
+FROM debian:trixie-slim
+
+RUN apt-get update && \
+    apt-get install -y libdbus-1-3 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /app/target/release/bitchat /app/
+CMD ["./bitchat"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ A terminal client for BitChat - the decentralized, encrypted mesh network chat p
 - If you are having issues building the binary you can run ``cargo build --release`` and manually move the binary to ```/usr/local/bin``` 
 
 ## Running with Docker
+
+Build the image locally.
+```
+git clone https://github.com/ShilohEye/bitchat-terminal.git
+cd bitchat-terminal
+docker build -t bitchat-terminal .
+```
+
+Run the container (with Bluetooth support)
 ```
 docker run --rm -it --privileged \
   -v /dev:/dev \

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ A terminal client for BitChat - the decentralized, encrypted mesh network chat p
 
 - If you are having issues building the binary you can run ``cargo build --release`` and manually move the binary to ```/usr/local/bin``` 
 
+## Running with Docker
+```
+docker run --rm -it --privileged \
+  -v /dev:/dev \
+  --env DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket \
+  -v /run/dbus:/host/run/dbus \
+  bitchat-terminal
+```
+
 ## Installing Rust (First Time Users)
 
 If you don't have Rust installed:


### PR DESCRIPTION
Currently testing this on my laptop and also a RPi 4 successfully.