### PR TITLE
[WIP] Store and forward msg caching and connection health monitoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "bitchat"
 path = "src/main.rs"
 
 [dependencies]
-tokio = { version = "1", features = ["full", "process"] }
+tokio = { version = "1", features = ["full", "process", "time"] }
 btleplug = "0.11"
 rand = "0.8"
 uuid = { version = "1", features = ["v4"] }
@@ -23,6 +23,11 @@ chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dirs = "5.0"
+base64 = "0.21"
+thiserror = "1.0"
+
+# For Noise
+snow = "0.9"
 
 # For Cryptography
 x25519-dalek = { version = "2.0", features = ["static_secrets", "getrandom"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,8 @@ mod fragmentation;
 mod encryption;
 mod terminal_ux;
 mod persistence;
+mod noise;
+mod message_queue;
 
 use compression::decompress;
 use fragmentation::{Fragment, FragmentType};
@@ -3225,7 +3227,7 @@ mod tests {
         assert_eq!(FLAG_HAS_RECIPIENT, 0x01);
         assert_eq!(FLAG_HAS_SIGNATURE, 0x02);
         assert_eq!(FLAG_IS_COMPRESSED, 0x04);
-        assert_eq!(FLAG_HAS_CHANNEL, 0x40);
+        assert_eq!(MSG_FLAG_HAS_CHANNEL, 0x40);
         assert_eq!(SIGNATURE_SIZE, 64);
         assert_eq!(BROADCAST_RECIPIENT, [0xFF; 8]);
     }

--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -1,0 +1,806 @@
+#![allow(dead_code)]
+
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use serde::{Serialize, Deserialize};
+
+// Custom timestamp type that can be serialized
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Timestamp {
+    secs_since_epoch: u64,
+}
+
+impl Timestamp {
+    pub fn now() -> Self {
+        let duration = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default();
+        Self {
+            secs_since_epoch: duration.as_secs(),
+        }
+    }
+    
+    pub fn elapsed(&self) -> Duration {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        
+        Duration::from_secs(now.saturating_sub(self.secs_since_epoch))
+    }
+    
+    pub fn duration_since(&self, earlier: Timestamp) -> Duration {
+        Duration::from_secs(self.secs_since_epoch.saturating_sub(earlier.secs_since_epoch))
+    }
+    
+    pub fn add_duration(&self, duration: Duration) -> Self {
+        Self {
+            secs_since_epoch: self.secs_since_epoch + duration.as_secs(),
+        }
+    }
+}
+
+impl From<SystemTime> for Timestamp {
+    fn from(time: SystemTime) -> Self {
+        let duration = time.duration_since(UNIX_EPOCH).unwrap_or_default();
+        Self {
+            secs_since_epoch: duration.as_secs(),
+        }
+    }
+}
+
+impl Into<SystemTime> for Timestamp {
+    fn into(self) -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(self.secs_since_epoch)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueuedMessage {
+    pub message_id: String,
+    pub content: String,
+    pub recipient_peer_id: String,
+    pub recipient_nickname: String,
+    pub timestamp: Timestamp,
+    pub is_private: bool,
+    pub retry_count: u32,
+    pub channel: Option<String>,
+    pub max_retries: u32,
+    pub priority: MessagePriority,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MessagePriority {
+    Low = 0,
+    Normal = 1,
+    High = 2,
+    Critical = 3,
+}
+
+impl Default for MessagePriority {
+    fn default() -> Self {
+        MessagePriority::Normal
+    }
+}
+
+impl QueuedMessage {
+    pub fn new(
+        message_id: String,
+        content: String,
+        recipient_peer_id: String,
+        recipient_nickname: String,
+        is_private: bool,
+        channel: Option<String>,
+    ) -> Self {
+        Self {
+            message_id,
+            content,
+            recipient_peer_id,
+            recipient_nickname,
+            timestamp: Timestamp::now(),
+            is_private,
+            retry_count: 0,
+            channel,
+            max_retries: 3,
+            priority: MessagePriority::default(),
+        }
+    }
+    
+    pub fn with_priority(mut self, priority: MessagePriority) -> Self {
+        self.priority = priority;
+        self
+    }
+    
+    pub fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+    
+    pub fn age(&self) -> Duration {
+        self.timestamp.elapsed()
+    }
+    
+    pub fn increment_retry(&mut self) {
+        self.retry_count += 1;
+        self.timestamp = Timestamp::now(); // Reset timestamp for retry
+    }
+    
+    pub fn is_expired(&self, timeout: Duration) -> bool {
+        self.age() > timeout
+    }
+    
+    pub fn has_retries_left(&self) -> bool {
+        self.retry_count < self.max_retries
+    }
+    
+    pub fn should_retry(&self, retry_timeout: Duration) -> bool {
+        self.has_retries_left() && self.is_expired(retry_timeout)
+    }
+    
+    pub fn get_next_retry_delay(&self) -> Duration {
+        // Exponential backoff: 1s, 2s, 4s, 8s, etc.
+        let base_delay = Duration::from_secs(1);
+        let multiplier = 2_u32.pow(self.retry_count);
+        base_delay * multiplier.min(60) // Cap at 60 seconds
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageQueueConfig {
+    pub max_retries: u32,
+    pub message_timeout: Duration,
+    pub retry_timeout: Duration,
+    pub max_queue_size_per_peer: usize,
+    pub max_total_queue_size: usize,
+    pub cleanup_interval: Duration,
+}
+
+impl Default for MessageQueueConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            message_timeout: Duration::from_secs(300), // 5 minutes
+            retry_timeout: Duration::from_secs(30),     // 30 seconds
+            max_queue_size_per_peer: 50,
+            max_total_queue_size: 500,
+            cleanup_interval: Duration::from_secs(60), // 1 minute
+        }
+    }
+}
+
+pub struct MessageQueue {
+    pending_messages: HashMap<String, VecDeque<QueuedMessage>>, // peer_id -> msg
+    config: MessageQueueConfig,
+    last_cleanup: Timestamp,
+    total_messages: usize,
+}
+
+impl MessageQueue {
+    pub fn new() -> Self {
+        Self::with_config(MessageQueueConfig::default())
+    }
+    
+    pub fn with_config(config: MessageQueueConfig) -> Self {
+        Self {
+            pending_messages: HashMap::new(),
+            config,
+            last_cleanup: Timestamp::now(),
+            total_messages: 0,
+        }
+    }
+    
+    pub fn queue_message(&mut self, mut message: QueuedMessage) -> bool {
+        // Apply default config if not set
+        if message.max_retries == 0 {
+            message.max_retries = self.config.max_retries;
+        }
+        
+        let peer_id = message.recipient_peer_id.clone();
+        
+        // Check total queue size limit
+        if self.total_messages >= self.config.max_total_queue_size {
+            self.evict_oldest_messages();
+        }
+        
+        let queue = self.pending_messages.entry(peer_id).or_insert_with(VecDeque::new);
+        
+        // Check per-peer queue size limit
+        if queue.len() >= self.config.max_queue_size_per_peer {
+            // Remove oldest msg for this peer
+            if queue.pop_front().is_some() {
+                self.total_messages = self.total_messages.saturating_sub(1);
+            }
+        }
+        
+        // Insert msg in priority order (higher priority first)
+        let insert_pos = queue.iter().position(|msg| msg.priority < message.priority)
+            .unwrap_or(queue.len());
+        
+        queue.insert(insert_pos, message);
+        self.total_messages += 1;
+        
+        true
+    }
+    
+    pub fn get_pending_messages(&mut self, peer_id: &str) -> Vec<QueuedMessage> {
+        if let Some(queue) = self.pending_messages.remove(peer_id) {
+            let messages: Vec<QueuedMessage> = queue.into_iter().collect();
+            self.total_messages = self.total_messages.saturating_sub(messages.len());
+            messages
+        } else {
+            Vec::new()
+        }
+    }
+    
+    pub fn peek_pending_messages(&self, peer_id: &str) -> Vec<QueuedMessage> {
+        self.pending_messages
+            .get(peer_id)
+            .map(|queue| queue.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+    
+    pub fn has_pending_messages(&self, peer_id: &str) -> bool {
+        self.pending_messages
+            .get(peer_id)
+            .map(|queue| !queue.is_empty())
+            .unwrap_or(false)
+    }
+    
+    pub fn get_total_queued(&self) -> usize {
+        self.total_messages
+    }
+    
+    pub fn get_queue_summary(&self) -> Vec<(String, usize)> {
+        self.pending_messages
+            .iter()
+            .map(|(peer_id, queue)| (peer_id.clone(), queue.len()))
+            .collect()
+    }
+    
+    pub fn get_detailed_summary(&self) -> HashMap<String, Vec<QueuedMessage>> {
+        self.pending_messages
+            .iter()
+            .map(|(peer_id, queue)| (peer_id.clone(), queue.iter().cloned().collect()))
+            .collect()
+    }
+    
+    pub fn get_priority_summary(&self) -> HashMap<MessagePriority, usize> {
+        let mut summary = HashMap::new();
+        
+        for queue in self.pending_messages.values() {
+            for message in queue {
+                *summary.entry(message.priority).or_insert(0) += 1;
+            }
+        }
+        
+        summary
+    }
+    
+    pub fn cleanup_expired(&mut self) {
+        let now = Timestamp::now();
+        let mut removed_count = 0;
+        
+        for queue in self.pending_messages.values_mut() {
+            let original_len = queue.len();
+            queue.retain(|msg| !msg.is_expired(self.config.message_timeout));
+            removed_count += original_len - queue.len();
+        }
+        
+        // Remove empty queues
+        self.pending_messages.retain(|_, queue| !queue.is_empty());
+        self.total_messages = self.total_messages.saturating_sub(removed_count);
+        self.last_cleanup = now;
+    }
+    
+    pub fn get_failed_deliveries(&mut self) -> Vec<QueuedMessage> {
+        let mut failed = Vec::new();
+        let mut removed_count = 0;
+        
+        for queue in self.pending_messages.values_mut() {
+            let mut to_retry = VecDeque::new();
+            
+            while let Some(mut msg) = queue.pop_front() {
+                if msg.should_retry(self.config.retry_timeout) {
+                    msg.increment_retry();
+                    failed.push(msg);
+                    removed_count += 1;
+                } else if msg.is_expired(self.config.message_timeout) {
+                    // msg expired completely, drop it
+                    removed_count += 1;
+                } else {
+                    // msg not ready for retry yet
+                    to_retry.push_back(msg);
+                }
+            }
+            
+            *queue = to_retry;
+        }
+        
+        // Remove empty queues
+        self.pending_messages.retain(|_, queue| !queue.is_empty());
+        self.total_messages = self.total_messages.saturating_sub(removed_count);
+        
+        failed
+    }
+    
+    pub fn remove_message(&mut self, peer_id: &str, message_id: &str) -> bool {
+        if let Some(queue) = self.pending_messages.get_mut(peer_id) {
+            if let Some(pos) = queue.iter().position(|msg| msg.message_id == message_id) {
+                queue.remove(pos);
+                self.total_messages = self.total_messages.saturating_sub(1);
+                
+                // Remove empty queue
+                if queue.is_empty() {
+                    self.pending_messages.remove(peer_id);
+                }
+                
+                return true;
+            }
+        }
+        false
+    }
+    
+    pub fn get_messages_for_peer(&self, peer_id: &str) -> Vec<QueuedMessage> {
+        self.pending_messages
+            .get(peer_id)
+            .map(|queue| queue.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+    
+    pub fn get_high_priority_messages(&mut self) -> Vec<(String, QueuedMessage)> {
+        let mut high_priority = Vec::new();
+        let mut removed_count = 0;
+        
+        for (peer_id, queue) in self.pending_messages.iter_mut() {
+            let mut remaining = VecDeque::new();
+            
+            while let Some(msg) = queue.pop_front() {
+                if msg.priority >= MessagePriority::High {
+                    high_priority.push((peer_id.clone(), msg));
+                    removed_count += 1;
+                } else {
+                    remaining.push_back(msg);
+                }
+            }
+            
+            *queue = remaining;
+        }
+        
+        // Remove empty queues
+        self.pending_messages.retain(|_, queue| !queue.is_empty());
+        self.total_messages = self.total_messages.saturating_sub(removed_count);
+        
+        // Sort by priority (highest first)
+        high_priority.sort_by(|a, b| b.1.priority.cmp(&a.1.priority));
+        
+        high_priority
+    }
+    
+    pub fn should_cleanup(&self) -> bool {
+        self.last_cleanup.elapsed() >= self.config.cleanup_interval
+    }
+    
+    pub fn get_stats(&self) -> MessageQueueStats {
+        let mut stats = MessageQueueStats::default();
+        
+        stats.total_messages = self.total_messages;
+        stats.total_peers = self.pending_messages.len();
+        
+        for queue in self.pending_messages.values() {
+            for message in queue {
+                match message.priority {
+                    MessagePriority::Critical => stats.critical_messages += 1,
+                    MessagePriority::High => stats.high_priority_messages += 1,
+                    MessagePriority::Normal => stats.normal_messages += 1,
+                    MessagePriority::Low => stats.low_priority_messages += 1,
+                }
+                
+                if message.is_private {
+                    stats.private_messages += 1;
+                } else {
+                    stats.public_messages += 1;
+                }
+                
+                if message.retry_count > 0 {
+                    stats.retry_messages += 1;
+                }
+            }
+        }
+        
+        stats
+    }
+    
+    fn evict_oldest_messages(&mut self) {
+        // Remove 10% of msg, starting with oldest and lowest priority
+        let target_remove = (self.total_messages / 10).max(1);
+        let mut removed = 0;
+        
+        // Collect all msg with their metadata for sorting
+        let mut all_messages: Vec<(String, usize, QueuedMessage)> = Vec::new();
+        
+        for (peer_id, queue) in &self.pending_messages {
+            for (index, message) in queue.iter().enumerate() {
+                all_messages.push((peer_id.clone(), index, message.clone()));
+            }
+        }
+        
+        // Sort by priority (low first) then by age (old first)
+        all_messages.sort_by(|a, b| {
+            a.2.priority.cmp(&b.2.priority)
+                .then_with(|| a.2.timestamp.secs_since_epoch.cmp(&b.2.timestamp.secs_since_epoch))
+        });
+        
+        // Remove the oldest, lowest priority msg
+        for (peer_id, _, _) in all_messages.iter().take(target_remove) {
+            if let Some(queue) = self.pending_messages.get_mut(peer_id) {
+                if queue.pop_front().is_some() {
+                    removed += 1;
+                }
+            }
+        }
+        
+        // Remove empty queues
+        self.pending_messages.retain(|_, queue| !queue.is_empty());
+        self.total_messages = self.total_messages.saturating_sub(removed);
+    }
+    
+    pub fn clear(&mut self) {
+        self.pending_messages.clear();
+        self.total_messages = 0;
+    }
+    
+    pub fn clear_peer(&mut self, peer_id: &str) -> usize {
+        if let Some(queue) = self.pending_messages.remove(peer_id) {
+            let count = queue.len();
+            self.total_messages = self.total_messages.saturating_sub(count);
+            count
+        } else {
+            0
+        }
+    }
+}
+
+impl Default for MessageQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct MessageQueueStats {
+    pub total_messages: usize,
+    pub total_peers: usize,
+    pub private_messages: usize,
+    pub public_messages: usize,
+    pub critical_messages: usize,
+    pub high_priority_messages: usize,
+    pub normal_messages: usize,
+    pub low_priority_messages: usize,
+    pub retry_messages: usize,
+}
+
+impl MessageQueueStats {
+    pub fn print_summary(&self) {
+        println!("  Message Queue Statistics:");
+        println!("  Total messages: {}", self.total_messages);
+        println!("  Total peers: {}", self.total_peers);
+        println!("  Private: {}, Public: {}", self.private_messages, self.public_messages);
+        println!("  Priority - Critical: {}, High: {}, Normal: {}, Low: {}", 
+                 self.critical_messages, self.high_priority_messages, 
+                 self.normal_messages, self.low_priority_messages);
+        println!("  Messages with retries: {}", self.retry_messages);
+    }
+}
+
+impl MessageQueue {
+    pub fn save_to_file(&self, path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+        let data = serde_json::to_string_pretty(&self.pending_messages)?;
+        std::fs::write(path, data)?;
+        Ok(())
+    }
+    
+    pub fn load_from_file(&mut self, path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+        if path.exists() {
+            let data = std::fs::read_to_string(path)?;
+            let messages: HashMap<String, VecDeque<QueuedMessage>> = serde_json::from_str(&data)?;
+            
+            // Calculate total msg
+            let total = messages.values().map(|queue| queue.len()).sum();
+            
+            self.pending_messages = messages;
+            self.total_messages = total;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_message_queue_basic() {
+        let mut queue = MessageQueue::new();
+        
+        let message = QueuedMessage::new(
+            "msg1".to_string(),
+            "Hello".to_string(),
+            "peer1".to_string(),
+            "Alice".to_string(),
+            true,
+            None,
+        );
+        
+        assert!(queue.queue_message(message));
+        assert_eq!(queue.get_total_queued(), 1);
+        assert!(queue.has_pending_messages("peer1"));
+        
+        let messages = queue.get_pending_messages("peer1");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].content, "Hello");
+        assert_eq!(queue.get_total_queued(), 0);
+    }
+    
+    #[test]
+    fn test_message_priority() {
+        let mut queue = MessageQueue::new();
+        
+        // Add msg with different priorities
+        let normal_msg = QueuedMessage::new(
+            "msg1".to_string(),
+            "Normal".to_string(),
+            "peer1".to_string(),
+            "Alice".to_string(),
+            false,
+            None,
+        );
+        
+        let high_msg = QueuedMessage::new(
+            "msg2".to_string(),
+            "High".to_string(),
+            "peer1".to_string(),
+            "Alice".to_string(),
+            false,
+            None,
+        ).with_priority(MessagePriority::High);
+        
+        let critical_msg = QueuedMessage::new(
+            "msg3".to_string(),
+            "Critical".to_string(),
+            "peer1".to_string(),
+            "Alice".to_string(),
+            false,
+            None,
+        ).with_priority(MessagePriority::Critical);
+        
+        // Add in reverse priority order
+        queue.queue_message(normal_msg);
+        queue.queue_message(high_msg);
+        queue.queue_message(critical_msg);
+        
+        let messages = queue.get_pending_messages("peer1");
+        assert_eq!(messages.len(), 3);
+        
+        // Should be ordered by priority (highest first)
+        assert_eq!(messages[0].content, "Critical");
+        assert_eq!(messages[1].content, "High");
+        assert_eq!(messages[2].content, "Normal");
+    }
+    
+    #[test]
+    fn test_message_expiration() {
+        let mut config = MessageQueueConfig::default();
+        config.message_timeout = Duration::from_secs(1);
+        
+        let mut queue = MessageQueue::with_config(config);
+        
+        let mut message = QueuedMessage::new(
+            "msg1".to_string(),
+            "Test".to_string(),
+            "peer1".to_string(),
+            "Alice".to_string(),
+            false,
+            None,
+        );
+        
+        // Manually set old timestamp
+        message.timestamp = Timestamp {
+            secs_since_epoch: 0, // Very old timestamp
+        };
+        
+        queue.queue_message(message);
+        assert_eq!(queue.get_total_queued(), 1);
+        
+        queue.cleanup_expired();
+        assert_eq!(queue.get_total_queued(), 0);
+    }
+    
+    #[test]
+    fn test_retry_logic() {
+        let mut config = MessageQueueConfig::default();
+        config.retry_timeout = Duration::from_secs(0);
+        config.max_retries = 2;
+        
+        let mut queue = MessageQueue::with_config(config);
+        
+        let mut message = QueuedMessage::new(
+            "msg1".to_string(),
+            "Test".to_string(),
+            "peer1".to_string(),
+            "Alice".to_string(),
+            false,
+            None,
+        ).with_max_retries(2);
+        
+        message.timestamp = Timestamp {
+            secs_since_epoch: 1,
+        };
+        
+        queue.queue_message(message);
+        
+        let failed = queue.get_failed_deliveries();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].retry_count, 1);
+        
+        // Queue the failed msg again with old timestamp
+        let mut retry_msg = failed[0].clone();
+        retry_msg.timestamp = Timestamp { secs_since_epoch: 1 };
+        queue.queue_message(retry_msg);
+        
+        let failed2 = queue.get_failed_deliveries();
+        assert_eq!(failed2.len(), 1);
+        assert_eq!(failed2[0].retry_count, 2);
+        
+        // Queue again should reach max retries and be dropped
+        let mut final_retry = failed2[0].clone();
+        final_retry.timestamp = Timestamp { secs_since_epoch: 1 };
+        queue.queue_message(final_retry);
+        
+        let failed3 = queue.get_failed_deliveries();
+        assert_eq!(failed3.len(), 0); // No more retries, msg dropped
+    }
+    
+    #[test]
+    fn test_queue_size_limits() {
+        let mut config = MessageQueueConfig::default();
+        config.max_queue_size_per_peer = 2;
+        config.max_total_queue_size = 3;
+        
+        let mut queue = MessageQueue::with_config(config);
+        
+        // Add 3 msg for peer1 (should evict oldest)
+        for i in 0..3 {
+            let message = QueuedMessage::new(
+                format!("msg{}", i),
+                format!("Content {}", i),
+                "peer1".to_string(),
+                "Alice".to_string(),
+                false,
+                None,
+            );
+            queue.queue_message(message);
+        }
+        
+        // Should only have 2 msg for peer1 (per-peer limit)
+        assert_eq!(queue.get_messages_for_peer("peer1").len(), 2);
+        
+        // Add msg for peer2 - should trigger total limit
+        let message = QueuedMessage::new(
+            "msg_peer2".to_string(),
+            "Content peer2".to_string(),
+            "peer2".to_string(),
+            "Bob".to_string(),
+            false,
+            None,
+        );
+        queue.queue_message(message);
+        
+        // Total should not exceed limit
+        assert!(queue.get_total_queued() <= 3);
+    }
+    
+    #[test]
+    fn test_high_priority_extraction() {
+        let mut queue = MessageQueue::new();
+        
+        // Add mix of priorities
+        let messages = vec![
+            ("Normal 1", MessagePriority::Normal),
+            ("High 1", MessagePriority::High),
+            ("Normal 2", MessagePriority::Normal),
+            ("Critical 1", MessagePriority::Critical),
+            ("High 2", MessagePriority::High),
+        ];
+        
+        for (i, (content, priority)) in messages.iter().enumerate() {
+            let message = QueuedMessage::new(
+                format!("msg{}", i),
+                content.to_string(),
+                "peer1".to_string(),
+                "Alice".to_string(),
+                false,
+                None,
+            ).with_priority(*priority);
+            queue.queue_message(message);
+        }
+        
+        let high_priority = queue.get_high_priority_messages();
+        assert_eq!(high_priority.len(), 3); // 1 Critical + 2 High
+        
+        // Should be sorted by priority (Critical first)
+        assert_eq!(high_priority[0].1.content, "Critical 1");
+        assert!(high_priority[1].1.content.starts_with("High"));
+        assert!(high_priority[2].1.content.starts_with("High"));
+        
+        // Remaining msg should be Normal priority only
+        let remaining = queue.get_messages_for_peer("peer1");
+        assert_eq!(remaining.len(), 2);
+        assert!(remaining.iter().all(|msg| msg.priority == MessagePriority::Normal));
+    }
+    
+    #[test]
+    fn test_stats() {
+        let mut queue = MessageQueue::new();
+        
+        // Add various types of msg
+        let messages = vec![
+            (true, MessagePriority::Critical),
+            (false, MessagePriority::High),
+            (true, MessagePriority::Normal),
+            (false, MessagePriority::Low),
+        ];
+        
+        for (i, (is_private, priority)) in messages.iter().enumerate() {
+            let message = QueuedMessage::new(
+                format!("msg{}", i),
+                "Content".to_string(),
+                "peer1".to_string(),
+                "Alice".to_string(),
+                *is_private,
+                None,
+            ).with_priority(*priority);
+            queue.queue_message(message);
+        }
+        
+        let stats = queue.get_stats();
+        assert_eq!(stats.total_messages, 4);
+        assert_eq!(stats.private_messages, 2);
+        assert_eq!(stats.public_messages, 2);
+        assert_eq!(stats.critical_messages, 1);
+        assert_eq!(stats.high_priority_messages, 1);
+        assert_eq!(stats.normal_messages, 1);
+        assert_eq!(stats.low_priority_messages, 1);
+    }
+    
+    #[test]
+    fn test_serialization() {
+        let mut queue = MessageQueue::new();
+        
+        let message = QueuedMessage::new(
+            "msg1".to_string(),
+            "Test message".to_string(),
+            "peer1".to_string(),
+            "Alice".to_string(),
+            true,
+            Some("#general".to_string()),
+        ).with_priority(MessagePriority::High);
+        
+        queue.queue_message(message);
+        
+        // Test JSON serialization
+        let json = serde_json::to_string(&queue.pending_messages).unwrap();
+        assert!(json.contains("Test message"));
+        assert!(json.contains("Alice"));
+        assert!(json.contains("#general"));
+        
+        // Test deserialization
+        let deserialized: HashMap<String, VecDeque<QueuedMessage>> = 
+            serde_json::from_str(&json).unwrap();
+        
+        assert_eq!(deserialized.len(), 1);
+        let peer_queue = deserialized.get("peer1").unwrap();
+        assert_eq!(peer_queue.len(), 1);
+        assert_eq!(peer_queue[0].content, "Test message");
+        assert_eq!(peer_queue[0].priority, MessagePriority::High);
+    }
+}

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -1,0 +1,658 @@
+#![allow(dead_code)]
+
+use snow::{Builder, HandshakeState, TransportState, Error as SnowError};
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+use serde::{Serialize, Deserialize};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use sha2::{Sha256, Digest};
+use x25519_dalek::{StaticSecret, PublicKey};
+use rand::RngCore;
+use pbkdf2::pbkdf2_hmac;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use aes_gcm::aead::Aead;
+
+#[derive(Error, Debug)]
+pub enum NoiseError {
+    #[error("Snow error: {0}")]
+    Snow(#[from] SnowError),
+    #[error("Handshake not complete")]
+    HandshakeNotComplete,
+    #[error("Session not found for peer: {0}")]
+    SessionNotFound(String),
+    #[error("Invalid message format")]
+    InvalidMessage,
+    #[error("Handshake failed: {0}")]
+    HandshakeFailed(String),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("Base64 decode error: {0}")]
+    Base64(#[from] base64::DecodeError),
+    #[error("Invalid key length")]
+    InvalidKeyLength,
+}
+
+pub type NoiseResult<T> = Result<T, NoiseError>;
+
+pub struct NoiseSession {
+    pub peer_id: String,
+    transport: TransportState,
+    pub remote_static_key: Vec<u8>,
+    pub established_time: SystemTime,
+    pub sent_count: u64,
+    pub recv_count: u64,
+}
+
+impl NoiseSession {
+    pub fn new(peer_id: String, transport: TransportState, remote_static_key: Vec<u8>) -> Self {
+        Self {
+            peer_id,
+            transport,
+            remote_static_key,
+            established_time: SystemTime::now(),
+            sent_count: 0,
+            recv_count: 0,
+        }
+    }
+    
+    pub fn encrypt(&mut self, data: &[u8]) -> NoiseResult<Vec<u8>> {
+        let mut buf = vec![0u8; data.len() + 16];
+        let len = self.transport.write_message(data, &mut buf)?;
+        buf.truncate(len);
+        self.sent_count += 1;
+        Ok(buf)
+    }
+    
+    pub fn decrypt(&mut self, data: &[u8]) -> NoiseResult<Vec<u8>> {
+        let mut buf = vec![0u8; data.len()];
+        let len = self.transport.read_message(data, &mut buf)?;
+        buf.truncate(len);
+        self.recv_count += 1;
+        Ok(buf)
+    }
+    
+    pub fn get_fingerprint(&self) -> String {
+        let hash = Sha256::digest(&self.remote_static_key);
+        hex::encode(&hash[..16])
+    }
+    
+    pub fn age(&self) -> std::time::Duration {
+        SystemTime::now().duration_since(self.established_time).unwrap_or_default()
+    }
+    
+    pub fn get_remote_static_key(&self) -> &[u8] {
+        &self.remote_static_key
+    }
+}
+
+impl std::fmt::Debug for NoiseSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NoiseSession")
+            .field("peer_id", &self.peer_id)
+            .field("remote_static_key", &hex::encode(&self.remote_static_key))
+            .field("established_time", &self.established_time)
+            .field("sent_count", &self.sent_count)
+            .field("recv_count", &self.recv_count)
+            .finish()
+    }
+}
+
+pub struct NoiseHandshakeManager {
+    handshake: HandshakeState,
+    peer_id: String,
+    role: HandshakeRole,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum HandshakeRole {
+    Initiator,
+    Responder,
+}
+
+impl NoiseHandshakeManager {
+    pub fn new_initiator(peer_id: String, static_key: &[u8; 32]) -> NoiseResult<Self> {
+        let builder = Builder::new("Noise_XX_25519_ChaChaPoly_SHA256".parse()?);
+        let handshake = builder
+            .local_private_key(static_key)
+            .build_initiator()?;
+        
+        Ok(Self {
+            handshake,
+            peer_id,
+            role: HandshakeRole::Initiator,
+        })
+    }
+    
+    pub fn new_responder(peer_id: String, static_key: &[u8; 32]) -> NoiseResult<Self> {
+        let builder = Builder::new("Noise_XX_25519_ChaChaPoly_SHA256".parse()?);
+        let handshake = builder
+            .local_private_key(static_key)
+            .build_responder()?;
+        
+        Ok(Self {
+            handshake,
+            peer_id,
+            role: HandshakeRole::Responder,
+        })
+    }
+    
+    pub fn write_message(&mut self, payload: &[u8]) -> NoiseResult<Vec<u8>> {
+        // XX pattern msg can be up to ~100 bytes for handshake
+        let mut buf = vec![0u8; 512];
+        let len = self.handshake.write_message(payload, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+    
+    pub fn read_message(&mut self, message: &[u8]) -> NoiseResult<Vec<u8>> {
+        let mut buf = vec![0u8; 512];
+        let len = self.handshake.read_message(message, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+    
+    pub fn is_handshake_finished(&self) -> bool {
+        self.handshake.is_handshake_finished()
+    }
+    
+    pub fn get_role(&self) -> HandshakeRole {
+        self.role
+    }
+    
+    pub fn into_transport_mode(self) -> NoiseResult<NoiseSession> {
+        if !self.is_handshake_finished() {
+            return Err(NoiseError::HandshakeNotComplete);
+        }
+        
+        let transport = self.handshake.into_transport_mode()?;
+        let remote_static_key = transport.get_remote_static()
+            .ok_or(NoiseError::InvalidMessage)?
+            .to_vec();
+        
+        Ok(NoiseSession::new(self.peer_id, transport, remote_static_key))
+    }
+}
+
+impl std::fmt::Debug for NoiseHandshakeManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NoiseHandshakeManager")
+            .field("peer_id", &self.peer_id)
+            .field("role", &self.role)
+            .field("is_finished", &self.is_handshake_finished())
+            .finish()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NoiseIdentityAnnouncement {
+    #[serde(rename = "peerID")]
+    pub peer_id: String,
+    #[serde(rename = "publicKey")]
+    pub public_key: String, // base64 encoded
+    pub nickname: String,
+    pub timestamp: f64,
+    pub signature: String, // base64 encoded
+    #[serde(rename = "previousPeerID")]
+    pub previous_peer_id: Option<String>,
+}
+
+pub struct NoiseService {
+    static_key: [u8; 32],
+    sessions: HashMap<String, NoiseSession>,
+    handshake_states: HashMap<String, NoiseHandshakeManager>,
+    handshake_attempt_times: HashMap<String, SystemTime>,
+    handshake_timeout: std::time::Duration,
+    // Callbacks for events
+    on_peer_authenticated: Option<Box<dyn Fn(&str, &str) + Send + Sync>>,
+    on_handshake_required: Option<Box<dyn Fn(&str) + Send + Sync>>,
+}
+
+impl NoiseService {
+    pub fn new() -> Self {
+        let mut static_key = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut static_key);
+        
+        Self {
+            static_key,
+            sessions: HashMap::new(),
+            handshake_states: HashMap::new(),
+            handshake_attempt_times: HashMap::new(),
+            handshake_timeout: std::time::Duration::from_secs(5),
+            on_peer_authenticated: None,
+            on_handshake_required: None,
+        }
+    }
+    
+    pub fn with_static_key(static_key: [u8; 32]) -> Self {
+        Self {
+            static_key,
+            sessions: HashMap::new(),
+            handshake_states: HashMap::new(),
+            handshake_attempt_times: HashMap::new(),
+            handshake_timeout: std::time::Duration::from_secs(5),
+            on_peer_authenticated: None,
+            on_handshake_required: None,
+        }
+    }
+    
+    pub fn set_on_peer_authenticated<F>(&mut self, callback: F)
+    where
+        F: Fn(&str, &str) + Send + Sync + 'static,
+    {
+        self.on_peer_authenticated = Some(Box::new(callback));
+    }
+    
+    pub fn set_on_handshake_required<F>(&mut self, callback: F)
+    where
+        F: Fn(&str) + Send + Sync + 'static,
+    {
+        self.on_handshake_required = Some(Box::new(callback));
+    }
+    
+    pub fn get_public_key(&self) -> Vec<u8> {
+        let secret = StaticSecret::from(self.static_key);
+        let public = PublicKey::from(&secret);
+        public.as_bytes().to_vec()
+    }
+    
+    pub fn get_identity_fingerprint(&self) -> String {
+        let public_key = self.get_public_key();
+        let hash = Sha256::digest(&public_key);
+        hex::encode(&hash[..16])
+    }
+    
+    pub fn should_initiate_handshake(&mut self, peer_id: &str) -> bool {
+        let now = SystemTime::now();
+        
+        if let Some(last_attempt) = self.handshake_attempt_times.get(peer_id) {
+            if now.duration_since(*last_attempt).unwrap_or_default() < self.handshake_timeout {
+                return false; // Too recent
+            }
+        }
+        
+        self.handshake_attempt_times.insert(peer_id.to_string(), now);
+        true
+    }
+    
+    pub fn initiate_handshake(&mut self, peer_id: &str) -> NoiseResult<Vec<u8>> {
+        // Clean up any existing handshake state and session
+        self.handshake_states.remove(peer_id);
+        self.sessions.remove(peer_id);
+        
+        let mut handshake = NoiseHandshakeManager::new_initiator(
+            peer_id.to_string(),
+            &self.static_key
+        )?;
+        
+        let message = handshake.write_message(&[])?;
+        self.handshake_states.insert(peer_id.to_string(), handshake);
+        
+        Ok(message)
+    }
+    
+    pub fn process_handshake_message(&mut self, peer_id: &str, message: &[u8]) -> NoiseResult<Option<Vec<u8>>> {
+        // Validate input
+        if message.is_empty() {
+            return Err(NoiseError::InvalidMessage);
+        }
+        
+        if message.len() < 32 {
+            return Err(NoiseError::HandshakeFailed(
+                format!("Handshake message too short: {} bytes", message.len())
+            ));
+        }
+        
+        // Check if we have an ongoing handshake
+        if let Some(mut handshake) = self.handshake_states.remove(peer_id) {
+            // Continue existing handshake
+            let _payload = handshake.read_message(message)
+                .map_err(|e| NoiseError::HandshakeFailed(format!("Read message failed: {}", e)))?;
+            
+            let response = if !handshake.is_handshake_finished() {
+                Some(handshake.write_message(&[])?)
+            } else {
+                None
+            };
+            
+            if handshake.is_handshake_finished() {
+                // Handshake complete, create session
+                let session = handshake.into_transport_mode()?;
+                let fingerprint = session.get_fingerprint();
+                self.sessions.insert(peer_id.to_string(), session);
+                self.handshake_attempt_times.remove(peer_id);
+                
+                // Notify auth
+                if let Some(ref callback) = self.on_peer_authenticated {
+                    callback(peer_id, &fingerprint);
+                }
+            } else {
+                // Put handshake back
+                self.handshake_states.insert(peer_id.to_string(), handshake);
+            }
+            
+            Ok(response)
+        } else {
+            // New handshake from peer we are responder
+            let mut handshake = NoiseHandshakeManager::new_responder(
+                peer_id.to_string(),
+                &self.static_key
+            )?;
+            
+            let _payload = handshake.read_message(message)
+                .map_err(|e| NoiseError::HandshakeFailed(format!("Initial read failed: {}", e)))?;
+            
+            let response = handshake.write_message(&[])?;
+            
+            if handshake.is_handshake_finished() {
+                // Handshake complete in one round (shouldn't happen with XX)
+                let session = handshake.into_transport_mode()?;
+                let fingerprint = session.get_fingerprint();
+                self.sessions.insert(peer_id.to_string(), session);
+                
+                // Notify auth
+                if let Some(ref callback) = self.on_peer_authenticated {
+                    callback(peer_id, &fingerprint);
+                }
+            } else {
+                self.handshake_states.insert(peer_id.to_string(), handshake);
+            }
+            
+            Ok(Some(response))
+        }
+    }
+    
+    pub fn has_session(&self, peer_id: &str) -> bool {
+        self.sessions.contains_key(peer_id)
+    }
+    
+    pub fn is_session_established(&self, peer_id: &str) -> bool {
+        self.has_session(peer_id)
+    }
+    
+    pub fn encrypt(&mut self, peer_id: &str, data: &[u8]) -> NoiseResult<Vec<u8>> {
+        if !self.has_session(peer_id) {
+            if let Some(ref callback) = self.on_handshake_required {
+                callback(peer_id);
+            }
+            return Err(NoiseError::SessionNotFound(peer_id.to_string()));
+        }
+        
+        let session = self.sessions.get_mut(peer_id)
+            .ok_or_else(|| NoiseError::SessionNotFound(peer_id.to_string()))?;
+        session.encrypt(data)
+    }
+    
+    pub fn decrypt(&mut self, peer_id: &str, data: &[u8]) -> NoiseResult<Vec<u8>> {
+        let session = self.sessions.get_mut(peer_id)
+            .ok_or_else(|| NoiseError::SessionNotFound(peer_id.to_string()))?;
+        session.decrypt(data)
+    }
+    
+    pub fn encrypt_for_peer(&mut self, peer_id: &str, data: &[u8]) -> NoiseResult<Vec<u8>> {
+        self.encrypt(peer_id, data)
+    }
+    
+    pub fn decrypt_from_peer(&mut self, peer_id: &str, data: &[u8]) -> NoiseResult<Vec<u8>> {
+        self.decrypt(peer_id, data)
+    }
+    
+    pub fn get_peer_fingerprint(&self, peer_id: &str) -> Option<String> {
+        self.sessions.get(peer_id).map(|s| s.get_fingerprint())
+    }
+    
+    pub fn remove_session(&mut self, peer_id: &str) {
+        self.sessions.remove(peer_id);
+        self.handshake_states.remove(peer_id);
+        self.handshake_attempt_times.remove(peer_id);
+    }
+    
+    pub fn clear_handshake_state(&mut self, peer_id: &str) {
+        self.handshake_states.remove(peer_id);
+        self.handshake_attempt_times.remove(peer_id);
+    }
+    
+    pub fn cleanup_old_sessions(&mut self, max_age_secs: u64) {
+        let cutoff = SystemTime::now() - std::time::Duration::from_secs(max_age_secs);
+        
+        let expired_peers: Vec<String> = self.sessions
+            .iter()
+            .filter(|(_, session)| session.established_time < cutoff)
+            .map(|(peer_id, _)| peer_id.clone())
+            .collect();
+        
+        for peer_id in expired_peers {
+            self.remove_session(&peer_id);
+        }
+    }
+    
+    pub fn get_session_count(&self) -> usize {
+        self.sessions.len()
+    }
+    
+    pub fn get_pending_handshake_count(&self) -> usize {
+        self.handshake_states.len()
+    }
+    
+    pub fn get_active_peers(&self) -> Vec<String> {
+        self.sessions.keys().cloned().collect()
+    }
+    
+    pub fn get_session_info(&self) -> Vec<(String, SessionInfo)> {
+        self.sessions.iter().map(|(peer_id, session)| {
+            (peer_id.clone(), SessionInfo {
+                fingerprint: session.get_fingerprint(),
+                age: session.age(),
+                sent_count: session.sent_count,
+                recv_count: session.recv_count,
+            })
+        }).collect()
+    }
+    
+    pub fn get_all_sessions(&self) -> HashMap<String, SessionInfo> {
+        self.sessions.iter().map(|(peer_id, session)| {
+            (peer_id.clone(), SessionInfo {
+                fingerprint: session.get_fingerprint(),
+                age: session.age(),
+                sent_count: session.sent_count,
+                recv_count: session.recv_count,
+            })
+        }).collect()
+    }
+    
+    pub fn create_identity_announcement(&self, peer_id: &str, nickname: &str) -> NoiseResult<Vec<u8>> {
+        let public_key = self.get_public_key();
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        
+        // Signature data
+        let binding_data = format!("{}{}{}", peer_id, BASE64.encode(&public_key), timestamp);
+        let signature = self.sign_data(binding_data.as_bytes());
+        
+        let announcement = NoiseIdentityAnnouncement {
+            peer_id: peer_id.to_string(),
+            public_key: BASE64.encode(&public_key),
+            nickname: nickname.to_string(),
+            timestamp,
+            signature: BASE64.encode(&signature),
+            previous_peer_id: None, // TODO: Track previous peer ID for rotation
+        };
+        
+        Ok(serde_json::to_vec(&announcement)?)
+    }
+    
+    pub fn verify_identity_announcement(&self, data: &[u8]) -> NoiseResult<NoiseIdentityAnnouncement> {
+        let announcement: NoiseIdentityAnnouncement = serde_json::from_slice(data)
+            .map_err(|e| NoiseError::Json(e))?;
+        
+        // Verify signature
+        let public_key = BASE64.decode(&announcement.public_key)
+            .map_err(|e| NoiseError::Base64(e))?;
+        let signature = BASE64.decode(&announcement.signature)
+            .map_err(|e| NoiseError::Base64(e))?;
+        
+        let binding_data = format!("{}{}{}", 
+            announcement.peer_id, 
+            announcement.public_key, 
+            announcement.timestamp
+        );
+        
+        let expected_signature = self.verify_signature(&binding_data, &signature, &public_key);
+        if !expected_signature {
+            return Err(NoiseError::HandshakeFailed("Invalid signature".to_string()));
+        }
+        
+        Ok(announcement)
+    }
+    
+    fn sign_data(&self, data: &[u8]) -> Vec<u8> {
+        // using SHA256 + static key
+        // TODO: Ed25519 signatures
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        hasher.update(&self.static_key);
+        hasher.finalize().to_vec()
+    }
+    
+    fn verify_signature(&self, data: &str, signature: &[u8], _public_key: &[u8]) -> bool {
+        // TODO: Ed25519 verification
+        let expected = self.sign_data(data.as_bytes());
+        signature == expected
+    }
+    
+    // Channel encryption
+    pub fn encrypt_with_key(&self, data: &[u8], key: &[u8; 32]) -> NoiseResult<Vec<u8>> {
+        let cipher = Aes256Gcm::new_from_slice(key)
+            .map_err(|_| NoiseError::InvalidKeyLength)?;
+        
+        let mut nonce_bytes = [0u8; 12];
+        rand::thread_rng().fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        
+        let ciphertext = cipher.encrypt(nonce, data)
+            .map_err(|_| NoiseError::InvalidMessage)?;
+        
+        let mut result = Vec::with_capacity(12 + ciphertext.len());
+        result.extend_from_slice(&nonce_bytes);
+        result.extend_from_slice(&ciphertext);
+        
+        Ok(result)
+    }
+    
+    pub fn decrypt_with_key(&self, data: &[u8], key: &[u8; 32]) -> NoiseResult<Vec<u8>> {
+        if data.len() < 12 {
+            return Err(NoiseError::InvalidMessage);
+        }
+        
+        let cipher = Aes256Gcm::new_from_slice(key)
+            .map_err(|_| NoiseError::InvalidKeyLength)?;
+        
+        let nonce = Nonce::from_slice(&data[..12]);
+        let ciphertext = &data[12..];
+        
+        let plaintext = cipher.decrypt(nonce, ciphertext)
+            .map_err(|_| NoiseError::InvalidMessage)?;
+        
+        Ok(plaintext)
+    }
+    
+    // Channel key derivation
+    pub fn derive_channel_key(password: &str, channel: &str) -> [u8; 32] {
+        let mut key = [0u8; 32];
+        pbkdf2_hmac::<Sha256>(
+            password.as_bytes(),
+            channel.as_bytes(),
+            100_000,
+            &mut key,
+        );
+        key
+    }
+}
+
+impl Default for NoiseService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for NoiseService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NoiseService")
+            .field("session_count", &self.sessions.len())
+            .field("handshake_count", &self.handshake_states.len())
+            .field("fingerprint", &self.get_identity_fingerprint())
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionInfo {
+    pub fingerprint: String,
+    pub age: std::time::Duration,
+    pub sent_count: u64,
+    pub recv_count: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_noise_handshake() {
+        let mut alice = NoiseService::new();
+        let mut bob = NoiseService::new();
+        
+        // Alice initiates handshake
+        let msg1 = alice.initiate_handshake("bob").unwrap();
+        assert!(!msg1.is_empty());
+        
+        // Bob processes and responds
+        let msg2 = bob.process_handshake_message("alice", &msg1).unwrap().unwrap();
+        assert!(!msg2.is_empty());
+        
+        // Alice processes response
+        let msg3 = alice.process_handshake_message("bob", &msg2).unwrap();
+        
+        // Bob processes final message if it exists
+        if let Some(final_msg) = msg3 {
+            bob.process_handshake_message("alice", &final_msg).unwrap();
+        }
+        
+        // Both should have sessions now
+        assert!(alice.has_session("bob"));
+        assert!(bob.has_session("alice"));
+        
+        // Test encryption/decryption
+        let plaintext = b"Hello, Bob!";
+        let encrypted = alice.encrypt("bob", plaintext).unwrap();
+        let decrypted = bob.decrypt("alice", &encrypted).unwrap();
+        
+        assert_eq!(plaintext, &decrypted[..]);
+    }
+    
+    #[test]
+    fn test_identity_announcement() {
+        let service = NoiseService::new();
+        let announcement_data = service.create_identity_announcement("peer123", "Alice").unwrap();
+        let announcement = service.verify_identity_announcement(&announcement_data).unwrap();
+        
+        assert_eq!(announcement.peer_id, "peer123");
+        assert_eq!(announcement.nickname, "Alice");
+        assert!(!announcement.public_key.is_empty());
+        assert!(!announcement.signature.is_empty());
+    }
+    
+    #[test]
+    fn test_channel_encryption() {
+        let service = NoiseService::new();
+        let key = NoiseService::derive_channel_key("password123", "#general");
+        
+        let plaintext = b"Channel message";
+        let encrypted = service.encrypt_with_key(plaintext, &key).unwrap();
+        let decrypted = service.decrypt_with_key(&encrypted, &key).unwrap();
+        
+        assert_eq!(plaintext, &decrypted[..]);
+    }
+}


### PR DESCRIPTION
## Why?
The bitchat-terminal implementation has significant reliability issues:
1. msg are lost permanently when peers are temporarily offline or experience connection issues
2. no retry mechanism if a BLE write fails, the message disappears
3. no connection health monitoring - the terminal doesn't detect when peers disconnect

This impl adds the Store-and-Forward mechanism explicitly described in the [bitchat whitepaper](https://github.com/permissionlesstech/bitchat/blob/main/WHITEPAPER.md#store--forward-system) to address these reliability issues.

## Additions with this pr
### Connection Health Monitoring
- 30-second timeout detection to identify offline peers
- Real time peer activity tracking for all msg types
- Automatic peer cleanup when connections are lost

### Store-and-Forward msg caching
- 12-hour TTL for regular messages (per whitepaper specification)
- 100 message limit for regular peers (per whitepaper specification)
- 1000 message limit for favorite peers (per whitepaper specification)
- Automatic delivery when peers reconnect (todo!)
- Automatic message caching when peers are offline or unreachable

### msg Reliability & Retry Logic
- 5-second write timeouts to prevent infinite blocking (fixes hanging issue)
- Automatic retry mechanism with exponential backoff
- 3 retry attempts before marking msg as failed

### Automatic Maintenance
- Periodic cache cleanup every 5 minutes to remove expired msg
- Memory management with configurable limits per peer
- TTL enforcement to prevent indefinite storage growth

## Implementation
- `MessageCache` - Implements whitepaper's store-and-forward specification
- `MessageQueue` - Handles retry logic and delivery confirmation
- `ConnectionHealth` - Monitors peer connectivity and timeouts
- `send_with_cache_timeout()` - Replaces direct BLE writes with timeout handling

> **Backward compatibility: no breaking changes to existing protocol**

## Current Limitations & Discovered Issues
**Peer Discovery Between Terminal Instances**
- **Issue:** two bitchat-terminal instances cannot discover each other directly
- **Workaround:** Both can connect via bitchat-android as a bridge
- **Impact:** Limits direct terminal-to-terminal testing scenarios

## TODO
1. **Identity-based caching for cross-session message persistence**(necessary to further add other things)
- Issue: msg cached by ephemeral peer ID don't survive app restarts
- Cause: each bitchat-terminal session generates a new random peer ID
- Whitepaper Solution: use identity fingerprints for persistent peer recognition